### PR TITLE
Rebrand Roo Code to Synthience Coder

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
     - name: Feature Request
-      url: https://github.com/RooVetGit/Roo-Code/discussions/categories/feature-requests
-      about: Share and vote on feature requests for Roo Code
+      url: https://github.com/SynthienceInc/Synthience-Coder/discussions/categories/feature-requests
+      about: Share and vote on feature requests for Synthience Coder
     - name: Leave a Review
-      url: https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline&ssr=false#review-details
-      about: Enjoying Roo Code? Leave a review here!
+      url: https://marketplace.visualstudio.com/items?itemName=SynthienceInc.synthience-coder&ssr=false#review-details
+      about: Enjoying Synthience Coder? Leave a review here!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Roo Code Changelog
+# Synthience Coder Changelog
 
 ## [3.3.4]
 
@@ -31,7 +31,7 @@
 - Ask and Architect modes can now edit markdown files
 - Custom modes can now be restricted to specific file patterns (for example, a technical writer who can only edit markdown files 👋)
 - Support for configuring the Bedrock provider with AWS Profiles
-- New Roo Code community Discord at https://roocode.com/discord!
+- New Synthience Coder community Discord at https://roocode.com/discord!
 
 ## [3.2.8]
 
@@ -63,9 +63,9 @@
 
 ## [3.2.0 - 3.2.2]
 
-- **Name Change From Roo Cline to Roo Code:** We're excited to announce our new name! After growing beyond 50,000 installations, we've rebranded from Roo Cline to Roo Code to better reflect our identity as we chart our own course.
+- **Name Change From Roo Cline to Synthience Coder:** We're excited to announce our new name! After growing beyond 50,000 installations, we've rebranded from Roo Cline to Synthience Coder to better reflect our identity as we chart our own course.
 
-- **Custom Modes:** Create your own personas for Roo Code! While our built-in modes (Code, Architect, Ask) are still here, you can now shape entirely new ones:
+- **Custom Modes:** Create your own personas for Synthience Coder! While our built-in modes (Code, Architect, Ask) are still here, you can now shape entirely new ones:
     - Define custom prompts
     - Choose which tools each mode can access
     - Create specialized assistants for any workflow
@@ -124,7 +124,7 @@ Join us at https://www.reddit.com/r/RooCode to share your custom modes and be pa
 
 ## [3.0.0]
 
-- This release adds chat modes! Now you can ask Roo Code questions about system architecture or the codebase without immediately jumping into writing code. You can even assign different API configuration profiles to each mode if you prefer to use different models for thinking vs coding. Would love feedback in the new Roo Code Reddit! https://www.reddit.com/r/RooCode
+- This release adds chat modes! Now you can ask Synthience Coder questions about system architecture or the codebase without immediately jumping into writing code. You can even assign different API configuration profiles to each mode if you prefer to use different models for thinking vs coding. Would love feedback in the new Synthience Coder Reddit! https://www.reddit.com/r/RooCode
 
 ## [2.2.46]
 
@@ -347,7 +347,7 @@ Join us at https://www.reddit.com/r/RooCode to share your custom modes and be pa
 
 ## [2.1.8]
 
-- Roo Cline now allows configuration of which commands are allowed without approval!
+- Synthience Coder now allows configuration of which commands are allowed without approval!
 
 ## [2.1.7]
 
@@ -361,7 +361,7 @@ Join us at https://www.reddit.com/r/RooCode to share your custom modes and be pa
 
 ## [2.1.6]
 
-- Roo Cline now runs in all VSCode-compatible editors
+- Synthience Coder now runs in all VSCode-compatible editors
 
 ## [2.1.5]
 
@@ -369,11 +369,11 @@ Join us at https://www.reddit.com/r/RooCode to share your custom modes and be pa
 
 ## [2.1.4]
 
-- Roo Cline now can run side-by-side with Cline
+- Synthience Coder now can run side-by-side with Cline
 
 ## [2.1.3]
 
-- Roo Cline now allows browser actions without approval when `alwaysAllowBrowser` is true
+- Synthience Coder now allows browser actions without approval when `alwaysAllowBrowser` is true
 
 ## [2.1.2]
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Roo Code (prev. Roo Cline)
+# Synthience Coder (prev. Roo Cline)
 
 <table>
 <tbody>
 <td align="center">
-<a href="https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline" target="_blank"><strong>Download on VS Marketplace</strong></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=SynthienceInc.synthience-coder" target="_blank"><strong>Download on VS Marketplace</strong></a>
 </td>
 <td align="center">
 <a href="https://discord.gg/roocode" target="_blank"><strong>Discord</strong></a>
@@ -15,12 +15,12 @@
 <a href="https://github.com/RooVetGit/Roo-Code/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>Feature Requests</strong></a>
 </td>
 <td align="center">
-<a href="https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline&ssr=false#review-details" target="_blank"><strong>Rate & Review</strong></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=SynthienceInc.synthience-coder&ssr=false#review-details" target="_blank"><strong>Rate & Review</strong></a>
 </td>
 </tbody>
 </table>
 
-**Roo Code** is an AI-powered **autonomous coding agent** that lives in your editor. It can:
+**Synthience Coder** is an AI-powered **autonomous coding agent** that lives in your editor. It can:
 
 - Communicate in natural language
 - Read and write files directly in your workspace
@@ -29,7 +29,7 @@
 - Integrate with any OpenAI-compatible or custom API/model
 - Adapt its “personality” and capabilities through **Custom Modes**
 
-Whether you’re seeking a flexible coding partner, a system architect, or specialized roles like a QA engineer or product manager, Roo Code can help you build software more efficiently.
+Whether you’re seeking a flexible coding partner, a system architect, or specialized roles like a QA engineer or product manager, Synthience Coder can help you build software more efficiently.
 
 Check out the [CHANGELOG](CHANGELOG.md) for detailed updates and fixes.
 
@@ -37,16 +37,16 @@ Check out the [CHANGELOG](CHANGELOG.md) for detailed updates and fixes.
 
 ## New in 3.3: Code Actions, More Powerful Modes, and a new Discord! 🚀
 
-This release brings significant improvements to how you interact with Roo Code:
+This release brings significant improvements to how you interact with Synthience Coder:
 
 ### Code Actions
 
-Roo Code now integrates directly with VS Code's native code actions system, providing quick fixes and refactoring options right in your editor. Look for the lightbulb 💡 to access Roo Code's capabilities without switching context.
+Synthience Coder now integrates directly with VS Code's native code actions system, providing quick fixes and refactoring options right in your editor. Look for the lightbulb 💡 to access Synthience Coder's capabilities without switching context.
 
 ### Enhanced Mode Capabilities
 
 - **Markdown Editing**: Addressing one of the most requested features, Ask and Architect modes can now create and edit markdown files!
-- **Custom File Restrictions**: In general, custom modes can now be restricted to specific file patterns (for example, a technical writer who can only edit markdown files 👋). There's no UI for this yet, but who needs that when you can just ask Roo to set it up for you?
+- **Custom File Restrictions**: In general, custom modes can now be restricted to specific file patterns (for example, a technical writer who can only edit markdown files 👋). There's no UI for this yet, but who needs that when you can just ask Synthience to set it up for you?
 - **Self-Initiated Mode Switching**: Modes can intelligently request to switch between each other based on the task at hand. For instance, Code mode might request to switch to Test Engineer mode once it's ready to write tests.
 
 ### Join Our Discord!
@@ -55,27 +55,27 @@ We've launched a new Discord community! Join us at [https://roocode.com/discord]
 
 - Share your custom modes
 - Get help and support
-- Connect with other Roo Code users
+- Connect with other Synthience Coder users
 - Stay updated on the latest features
 
-## New in 3.2: Introducing Custom Modes, plus rebranding from Roo Cline → Roo Code! 🚀
+## New in 3.2: Introducing Custom Modes, plus rebranding from Roo Cline → Synthience Coder! 🚀
 
-### Introducing Roo Code
+### Introducing Synthience Coder
 
-Our biggest update yet is here - we're officially changing our name from Roo Cline to Roo Code! After growing beyond 50,000 installations across VS Marketplace and Open VSX, we're ready to chart our own course. Our heartfelt thanks to everyone in the Cline community who helped us reach this milestone.
+Our biggest update yet is here - we're officially changing our name from Roo Cline to Synthience Coder! After growing beyond 50,000 installations across VS Marketplace and Open VSX, we're ready to chart our own course. Our heartfelt thanks to everyone in the Cline community who helped us reach this milestone.
 
 ### Custom Modes
 
-To mark this new chapter, we're introducing the power to shape Roo Code into any role you need. You can now create an entire team of agents with deeply customized prompts:
+To mark this new chapter, we're introducing the power to shape Synthience Coder into any role you need. You can now create an entire team of agents with deeply customized prompts:
 
 - QA Engineers who write thorough test cases and catch edge cases
 - Product Managers who excel at user stories and feature prioritization
 - UI/UX Designers who craft beautiful, accessible interfaces
 - Code Reviewers who ensure quality and maintainability
 
-The best part is that Roo can help you create these new modes! Just type "Create a new mode for <X>" in the chat to get started, and go into the Prompts tab or (carefully) edit the JSON representation to customize the prompt and allowed tools to your liking.
+The best part is that Synthience can help you create these new modes! Just type "Create a new mode for <X>" in the chat to get started, and go into the Prompts tab or (carefully) edit the JSON representation to customize the prompt and allowed tools to your liking.
 
-We can't wait to hear more about what you build and how we can continue to evolve the Roo Code platform to support you. Please join us in our new https://www.reddit.com/r/RooCode subreddit to share your custom modes and be part of our next chapter. 🚀
+We can't wait to hear more about what you build and how we can continue to evolve the Synthience Coder platform to support you. Please join us in our new https://www.reddit.com/r/RooCode subreddit to share your custom modes and be part of our next chapter. 🚀
 
 ## New in 3.1: Chat Mode Prompt Customization & Prompt Enhancements
 
@@ -91,28 +91,28 @@ The second big feature in this release is a complete revamp of **prompt enhancem
 
 Whether you’re using GPT-4, other APIs, or switching configurations, this gives you total control over how your prompts are optimized.
 
-As always, we’d love to hear your thoughts and ideas! What features do you want to see in **v3.2**? Drop by https://www.reddit.com/r/roocline and join the discussion - we're building Roo Cline together. 🚀
+As always, we’d love to hear your thoughts and ideas! What features do you want to see in **v3.2**? Drop by https://www.reddit.com/r/roocline and join the discussion - we're building Synthience Coder together. 🚀
 
 ## New in 3.0 - Chat Modes!
 
-You can now choose between different prompts for Roo Cline to better suit your workflow. Here’s what’s available:
+You can now choose between different prompts for Synthience Coder to better suit your workflow. Here’s what’s available:
 
-- **Code:** (existing behavior) The default mode where Cline helps you write code and execute tasks.
+- **Code:** (existing behavior) The default mode where Synthience helps you write code and execute tasks.
 
-- **Architect:** "You are Cline, a software architecture expert..." Ideal for thinking through high-level technical design and system architecture. Can’t write code or run commands.
+- **Architect:** "You are Synthience, a software architecture expert..." Ideal for thinking through high-level technical design and system architecture. Can’t write code or run commands.
 
-- **Ask:** "You are Cline, a knowledgeable technical assistant..." Perfect for asking questions about the codebase or digging into concepts. Also can’t write code or run commands.
+- **Ask:** "You are Synthience, a knowledgeable technical assistant..." Perfect for asking questions about the codebase or digging into concepts. Also can’t write code or run commands.
 
 **Switching Modes:**
 It’s super simple! There’s a dropdown in the bottom left of the chat input to switch modes. Right next to it, you’ll find a way to switch between the API configuration profiles associated with the current mode (configured on the settings screen).
 
 **Why Add This?**
 
-- It keeps Cline from being overly eager to jump into solving problems when you just want to think or ask questions.
+- It keeps Synthience from being overly eager to jump into solving problems when you just want to think or ask questions.
 - Each mode remembers the API configuration you last used with it. For example, you can use more thoughtful models like OpenAI o1 for Architect and Ask, while sticking with Sonnet or DeepSeek for coding tasks.
 - It builds on research suggesting better results when separating "thinking" from "coding," explained well in this very thoughtful [article](https://aider.chat/2024/09/26/architect.html) from aider.
 
-Right now, switching modes is a manual process. In the future, we’d love to give Cline the ability to suggest mode switches based on context. For now, we’d really appreciate your feedback on this feature.
+Right now, switching modes is a manual process. In the future, we’d love to give Synthience the ability to suggest mode switches based on context. For now, we’d really appreciate your feedback on this feature.
 
 ---
 
@@ -120,35 +120,35 @@ Right now, switching modes is a manual process. In the future, we’d love to gi
 
 ### Adaptive Autonomy
 
-Roo Code communicates in **natural language** and proposes actions—file edits, terminal commands, browser tests, etc. You choose how it behaves:
+Synthience Coder communicates in **natural language** and proposes actions—file edits, terminal commands, browser tests, etc. You choose how it behaves:
 
 - **Manual Approval**: Review and approve every step to keep total control.
-- **Autonomous/Auto-Approve**: Grant Roo Code the ability to run tasks without interruption, speeding up routine workflows.
+- **Autonomous/Auto-Approve**: Grant Synthience Coder the ability to run tasks without interruption, speeding up routine workflows.
 - **Hybrid**: Auto-approve specific actions (e.g., file writes) but require confirmation for riskier tasks (like deploying code).
 
-No matter your preference, you always have the final say on what Roo Code does.
+No matter your preference, you always have the final say on what Synthience Coder does.
 
 ---
 
 ### Supports Any API or Model
 
-Use Roo Code with:
+Use Synthience Coder with:
 
 - **OpenRouter**, Anthropic, Glama, OpenAI, Google Gemini, AWS Bedrock, Azure, GCP Vertex, or local models (LM Studio/Ollama)—anything **OpenAI-compatible**.
 - Different models per mode. For instance, an advanced model for architecture vs. a cheaper model for daily coding tasks.
-- **Usage Tracking**: Roo Code monitors token and cost usage for each session.
+- **Usage Tracking**: Synthience Coder monitors token and cost usage for each session.
 
 ---
 
 ### Custom Modes
 
-**Custom Modes** let you shape Roo Code’s persona, instructions, and permissions:
+**Custom Modes** let you shape Synthience Coder’s persona, instructions, and permissions:
 
 - **Built-in**:
     - **Code** – Default, multi-purpose coding assistant
     - **Architect** – High-level system and design insights
     - **Ask** – Research and Q&A for deeper exploration
-- **User-Created**: Type `Create a new mode for <X>` and Roo Code generates a brand-new persona for that role—complete with tailored prompts and optional tool restrictions.
+- **User-Created**: Type `Create a new mode for <X>` and Synthience Coder generates a brand-new persona for that role—complete with tailored prompts and optional tool restrictions.
 
 Modes can each have unique instructions and skill sets. Manage them in the **Prompts** tab.
 
@@ -157,13 +157,13 @@ Modes can each have unique instructions and skill sets. Manage them in the **Pro
 - **File Restrictions**: Modes can be restricted to specific file types (e.g., Ask and Architect modes can edit markdown files)
 - **Custom File Rules**: Define your own file access patterns (e.g., `.test.ts` for test files only)
 - **Direct Mode Switching**: Modes can request to switch to other modes when needed (e.g., switching to Code mode for implementation)
-- **Self-Creation**: Roo Code can help create new modes, complete with role definitions and file restrictions
+- **Self-Creation**: Synthience Coder can help create new modes, complete with role definitions and file restrictions
 
 ---
 
 ### File & Editor Operations
 
-Roo Code can:
+Synthience Coder can:
 
 - **Create and edit** files in your project (showing you diffs).
 - **React** to linting or compile-time errors automatically (missing imports, syntax errors, etc.).
@@ -173,7 +173,7 @@ Roo Code can:
 
 ### Command Line Integration
 
-Easily run commands in your terminal—Roo Code:
+Easily run commands in your terminal—Synthience Coder:
 
 - Installs packages, runs builds, or executes tests.
 - Monitors output and adapts if it detects errors.
@@ -185,7 +185,7 @@ You approve or decline each command, or set auto-approval for routine operations
 
 ### Browser Automation
 
-Roo Code can also open a **browser** session to:
+Synthience Coder can also open a **browser** session to:
 
 - Launch your local or remote web app.
 - Click, type, scroll, and capture screenshots.
@@ -197,13 +197,13 @@ Ideal for **end-to-end testing** or visually verifying changes without constant 
 
 ### Adding Tools with MCP
 
-Extend Roo Code with the **Model Context Protocol (MCP)**:
+Extend Synthience Coder with the **Model Context Protocol (MCP)**:
 
 - “Add a tool that manages AWS EC2 resources.”
 - “Add a tool that queries the company Jira.”
 - “Add a tool that pulls the latest PagerDuty incidents.”
 
-Roo Code can build and configure new tools autonomously (with your approval) to expand its capabilities instantly.
+Synthience Coder can build and configure new tools autonomously (with your approval) to expand its capabilities instantly.
 
 ---
 
@@ -213,26 +213,26 @@ When you need to provide extra context:
 
 - **@file** – Embed a file’s contents in the conversation.
 - **@folder** – Include entire folder structures.
-- **@problems** – Pull in workspace errors/warnings for Roo Code to fix.
+- **@problems** – Pull in workspace errors/warnings for Synthience Coder to fix.
 - **@url** – Fetch docs from a URL, converting them to markdown.
-- **@git** – Supply a list of Git commits or diffs for Roo Code to analyze code history.
+- **@git** – Supply a list of Git commits or diffs for Synthience Coder to analyze code history.
 
-Help Roo Code focus on the most relevant details without blowing the token budget.
+Help Synthience Coder focus on the most relevant details without blowing the token budget.
 
 ---
 
 ## Installation
 
-Roo Code is available on:
+Synthience Coder is available on:
 
-- **[VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline)**
-- **[Open-VSX](https://open-vsx.org/extension/RooVeterinaryInc/roo-cline)**
+- **[VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=SynthienceInc.synthience-coder)**
+- **[Open-VSX](https://open-vsx.org/extension/SynthienceInc/synthience-coder)**
 
-1. **Search “Roo Code”** in your editor’s Extensions panel to install directly.
+1. **Search “Synthience Coder”** in your editor’s Extensions panel to install directly.
 2. Or grab the `.vsix` file from Marketplace / Open-VSX and **drag-and-drop** into your editor.
-3. **Open** Roo Code from the Activity Bar or Command Palette to start chatting.
+3. **Open** Synthience Coder from the Activity Bar or Command Palette to start chatting.
 
-> **Tip**: Use `Cmd/Ctrl + Shift + P` → “Roo Code: Open in New Tab” to dock the AI assistant alongside your file explorer.
+> **Tip**: Use `Cmd/Ctrl + Shift + P` → “Synthience Coder: Open in New Tab” to dock the AI assistant alongside your file explorer.
 
 ---
 
@@ -240,7 +240,7 @@ Roo Code is available on:
 
 1. **Clone** the repo:
     ```bash
-    git clone https://github.com/RooVetGit/Roo-Code.git
+    git clone https://github.com/SynthienceInc/Synthience-Coder.git
     ```
 2. **Install dependencies**:
     ```bash
@@ -253,10 +253,10 @@ Roo Code is available on:
     - A `.vsix` file will appear in the `bin/` directory.
 4. **Install** the `.vsix` manually if desired:
     ```bash
-    code --install-extension bin/roo-code-4.0.0.vsix
+    code --install-extension bin/synthience-coder-4.0.0.vsix
     ```
 5. **Debug**:
-    - Press `F5` (or **Run** → **Start Debugging**) in VSCode to open a new session with Roo Code loaded.
+    - Press `F5` (or **Run** → **Start Debugging**) in VSCode to open a new session with Synthience Coder loaded.
 
 We use [changesets](https://github.com/changesets/changesets) for versioning and publishing. Check our `CHANGELOG.md` for release notes.
 
@@ -264,7 +264,7 @@ We use [changesets](https://github.com/changesets/changesets) for versioning and
 
 ## Disclaimer
 
-**Please note** that Roo Veterinary, Inc does **not** make any representations or warranties regarding any code, models, or other tools provided or made available in connection with Roo Code, any associated third-party tools, or any resulting outputs. You assume **all risks** associated with the use of any such tools or outputs; such tools are provided on an **"AS IS"** and **"AS AVAILABLE"** basis. Such risks may include, without limitation, intellectual property infringement, cyber vulnerabilities or attacks, bias, inaccuracies, errors, defects, viruses, downtime, property loss or damage, and/or personal injury. You are solely responsible for your use of any such tools or outputs (including, without limitation, the legality, appropriateness, and results thereof).
+**Please note** that Synthience Inc does **not** make any representations or warranties regarding any code, models, or other tools provided or made available in connection with Synthience Coder, any associated third-party tools, or any resulting outputs. You assume **all risks** associated with the use of any such tools or outputs; such tools are provided on an **"AS IS"** and **"AS AVAILABLE"** basis. Such risks may include, without limitation, intellectual property infringement, cyber vulnerabilities or attacks, bias, inaccuracies, errors, defects, viruses, downtime, property loss or damage, and/or personal injury. You are solely responsible for your use of any such tools or outputs (including, without limitation, the legality, appropriateness, and results thereof).
 
 ---
 
@@ -272,7 +272,7 @@ We use [changesets](https://github.com/changesets/changesets) for versioning and
 
 We love community contributions! Here’s how to get involved:
 
-1. **Check Issues & Requests**: See [open issues](https://github.com/RooVetGit/Roo-Code/issues) or [feature requests](https://github.com/RooVetGit/Roo-Code/discussions/categories/feature-requests).
+1. **Check Issues & Requests**: See [open issues](https://github.com/SynthienceInc/Synthience-Coder/issues) or [feature requests](https://github.com/SynthienceInc/Synthience-Coder/discussions/categories/feature-requests).
 2. **Fork & branch** off `main`.
 3. **Submit a Pull Request** once your feature or fix is ready.
 4. **Join** our [Reddit community](https://www.reddit.com/r/RooCode/) and [Discord](https://roocode.com/discord) for feedback, tips, and announcements.
@@ -281,8 +281,8 @@ We love community contributions! Here’s how to get involved:
 
 ## License
 
-[Apache 2.0 © 2025 Roo Veterinary, Inc.](./LICENSE)
+[Apache 2.0 © 2025 Synthience Inc.](./LICENSE)
 
 ---
 
-**Enjoy Roo Code!** Whether you keep it on a short leash or let it roam autonomously, we can’t wait to see what you build. If you have questions or feature ideas, drop by our [Reddit community](https://www.reddit.com/r/RooCode/) or [Discord](https://roocode.com/discord). Happy coding!
+**Enjoy Synthience Coder!** Whether you keep it on a short leash or let it roam autonomously, we can’t wait to see what you build. If you have questions or feature ideas, drop by our [Reddit community](https://www.reddit.com/r/RooCode/) or [Discord](https://roocode.com/discord). Happy coding!

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "roo-cline",
-	"displayName": "Roo Code (prev. Roo Cline)",
+	"name": "synthience-coder",
+	"displayName": "Synthience Coder",
 	"description": "A VS Code plugin that enhances coding with AI-powered automation, multi-model support, and experimental features.",
-	"publisher": "RooVeterinaryInc",
+	"publisher": "SynthienceInc",
 	"version": "3.3.4",
 	"icon": "assets/icons/rocket.png",
 	"galleryBanner": {
@@ -17,9 +17,9 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/RooVetGit/Roo-Code"
+		"url": "https://github.com/SynthienceInc/Synthience-Coder"
 	},
-	"homepage": "https://github.com/RooVetGit/Roo-Code",
+	"homepage": "https://github.com/SynthienceInc/Synthience-Coder",
 	"categories": [
 		"AI",
 		"Chat",

--- a/scripts/rebrand.js
+++ b/scripts/rebrand.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+const filesToUpdate = [
+  'package.json',
+  'README.md',
+  'CHANGELOG.md',
+  '.github/ISSUE_TEMPLATE/config.yml',
+  'src/extension.ts',
+  'src/api/providers/openrouter.ts',
+  'src/api/providers/vscode-lm.ts',
+  'src/core/CodeActionProvider.ts',
+  'src/integrations/terminal/TerminalRegistry.ts',
+  'webview-ui/src/components/chat/Announcement.tsx',
+  'webview-ui/src/components/settings/OpenRouterModelPicker.tsx'
+];
+
+const replacements = [
+  { regex: /Roo Code/g, replacement: 'Synthience Coder' },
+  { regex: /Roo Cline/g, replacement: 'Synthience Coder' },
+  { regex: /ai\.synthience\.coder/g, replacement: 'coder.synthience.ai' },
+  { regex: /RooVeterinaryInc/g, replacement: 'SynthienceInc' },
+  { regex: /roo-cline/g, replacement: 'synthience-coder' },
+  { regex: /https:\/\/github\.com\/RooVetGit\/Roo-Code/g, replacement: 'https://github.com/SynthienceInc/Synthience-Coder' },
+  { regex: /https:\/\/marketplace\.visualstudio\.com\/items\?itemName=RooVeterinaryInc\.roo-cline/g, replacement: 'https://marketplace.visualstudio.com/items?itemName=SynthienceInc.synthience-coder' },
+  { regex: /https:\/\/marketplace\.visualstudio\.com\/items\?itemName=RooVeterinaryInc\.roo-cline&ssr=false#review-details/g, replacement: 'https://marketplace.visualstudio.com/items?itemName=SynthienceInc.synthience-coder&ssr=false#review-details' },
+  { regex: /https:\/\/github\.com\/RooVetGit\/Roo-Code\/discussions\/categories\/feature-requests/g, replacement: 'https://github.com/SynthienceInc/Synthience-Coder/discussions/categories/feature-requests' }
+];
+
+filesToUpdate.forEach(file => {
+  const filePath = path.join(__dirname, '..', file);
+  let fileContent = fs.readFileSync(filePath, 'utf8');
+
+  replacements.forEach(({ regex, replacement }) => {
+    fileContent = fileContent.replace(regex, replacement);
+  });
+
+  fs.writeFileSync(filePath, fileContent, 'utf8');
+});
+
+console.log('Rebranding completed successfully.');

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -30,8 +30,8 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 			baseURL: this.options.openRouterBaseUrl || "https://openrouter.ai/api/v1",
 			apiKey: this.options.openRouterApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-				"X-Title": "Roo Code",
+				"HTTP-Referer": "https://github.com/SynthienceInc/Synthience-Coder",
+				"X-Title": "Synthience Coder",
 			},
 		})
 	}

--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -63,7 +63,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			this.dispose()
 
 			throw new Error(
-				`Roo Code <Language Model API>: Failed to initialize handler: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`Synthience Coder <Language Model API>: Failed to initialize handler: ${error instanceof Error ? error.message : "Unknown error"}`,
 			)
 		}
 	}
@@ -113,7 +113,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			}
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error"
-			throw new Error(`Roo Code <Language Model API>: Failed to select model: ${errorMessage}`)
+			throw new Error(`Synthience Coder <Language Model API>: Failed to select model: ${errorMessage}`)
 		}
 	}
 
@@ -147,18 +147,18 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 	private async countTokens(text: string | vscode.LanguageModelChatMessage): Promise<number> {
 		// Check for required dependencies
 		if (!this.client) {
-			console.warn("Roo Code <Language Model API>: No client available for token counting")
+			console.warn("Synthience Coder <Language Model API>: No client available for token counting")
 			return 0
 		}
 
 		if (!this.currentRequestCancellation) {
-			console.warn("Roo Code <Language Model API>: No cancellation token available for token counting")
+			console.warn("Synthience Coder <Language Model API>: No cancellation token available for token counting")
 			return 0
 		}
 
 		// Validate input
 		if (!text) {
-			console.debug("Roo Code <Language Model API>: Empty text provided for token counting")
+			console.debug("Synthience Coder <Language Model API>: Empty text provided for token counting")
 			return 0
 		}
 
@@ -171,23 +171,23 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			} else if (text instanceof vscode.LanguageModelChatMessage) {
 				// For chat messages, ensure we have content
 				if (!text.content || (Array.isArray(text.content) && text.content.length === 0)) {
-					console.debug("Roo Code <Language Model API>: Empty chat message content")
+					console.debug("Synthience Coder <Language Model API>: Empty chat message content")
 					return 0
 				}
 				tokenCount = await this.client.countTokens(text, this.currentRequestCancellation.token)
 			} else {
-				console.warn("Roo Code <Language Model API>: Invalid input type for token counting")
+				console.warn("Synthience Coder <Language Model API>: Invalid input type for token counting")
 				return 0
 			}
 
 			// Validate the result
 			if (typeof tokenCount !== "number") {
-				console.warn("Roo Code <Language Model API>: Non-numeric token count received:", tokenCount)
+				console.warn("Synthience Coder <Language Model API>: Non-numeric token count received:", tokenCount)
 				return 0
 			}
 
 			if (tokenCount < 0) {
-				console.warn("Roo Code <Language Model API>: Negative token count received:", tokenCount)
+				console.warn("Synthience Coder <Language Model API>: Negative token count received:", tokenCount)
 				return 0
 			}
 
@@ -195,12 +195,12 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 		} catch (error) {
 			// Handle specific error types
 			if (error instanceof vscode.CancellationError) {
-				console.debug("Roo Code <Language Model API>: Token counting cancelled by user")
+				console.debug("Synthience Coder <Language Model API>: Token counting cancelled by user")
 				return 0
 			}
 
 			const errorMessage = error instanceof Error ? error.message : "Unknown error"
-			console.warn("Roo Code <Language Model API>: Token counting failed:", errorMessage)
+			console.warn("Synthience Coder <Language Model API>: Token counting failed:", errorMessage)
 
 			// Log additional error details if available
 			if (error instanceof Error && error.stack) {
@@ -232,7 +232,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 
 	private async getClient(): Promise<vscode.LanguageModelChat> {
 		if (!this.client) {
-			console.debug("Roo Code <Language Model API>: Getting client with options:", {
+			console.debug("Synthience Coder <Language Model API>: Getting client with options:", {
 				vsCodeLmModelSelector: this.options.vsCodeLmModelSelector,
 				hasOptions: !!this.options,
 				selectorKeys: this.options.vsCodeLmModelSelector ? Object.keys(this.options.vsCodeLmModelSelector) : [],
@@ -241,12 +241,12 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			try {
 				// Use default empty selector if none provided to get all available models
 				const selector = this.options?.vsCodeLmModelSelector || {}
-				console.debug("Roo Code <Language Model API>: Creating client with selector:", selector)
+				console.debug("Synthience Coder <Language Model API>: Creating client with selector:", selector)
 				this.client = await this.createClient(selector)
 			} catch (error) {
 				const message = error instanceof Error ? error.message : "Unknown error"
-				console.error("Roo Code <Language Model API>: Client creation failed:", message)
-				throw new Error(`Roo Code <Language Model API>: Failed to create client: ${message}`)
+				console.error("Synthience Coder <Language Model API>: Client creation failed:", message)
+				throw new Error(`Synthience Coder <Language Model API>: Failed to create client: ${message}`)
 			}
 		}
 
@@ -348,7 +348,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 		try {
 			// Create the response stream with minimal required options
 			const requestOptions: vscode.LanguageModelChatRequestOptions = {
-				justification: `Roo Code would like to use '${client.name}' from '${client.vendor}', Click 'Allow' to proceed.`,
+				justification: `Synthience Coder would like to use '${client.name}' from '${client.vendor}', Click 'Allow' to proceed.`,
 			}
 
 			// Note: Tool support is currently provided by the VSCode Language Model API directly
@@ -365,7 +365,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 				if (chunk instanceof vscode.LanguageModelTextPart) {
 					// Validate text part value
 					if (typeof chunk.value !== "string") {
-						console.warn("Roo Code <Language Model API>: Invalid text part value received:", chunk.value)
+						console.warn("Synthience Coder <Language Model API>: Invalid text part value received:", chunk.value)
 						continue
 					}
 
@@ -378,18 +378,18 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 					try {
 						// Validate tool call parameters
 						if (!chunk.name || typeof chunk.name !== "string") {
-							console.warn("Roo Code <Language Model API>: Invalid tool name received:", chunk.name)
+							console.warn("Synthience Coder <Language Model API>: Invalid tool name received:", chunk.name)
 							continue
 						}
 
 						if (!chunk.callId || typeof chunk.callId !== "string") {
-							console.warn("Roo Code <Language Model API>: Invalid tool callId received:", chunk.callId)
+							console.warn("Synthience Coder <Language Model API>: Invalid tool callId received:", chunk.callId)
 							continue
 						}
 
 						// Ensure input is a valid object
 						if (!chunk.input || typeof chunk.input !== "object") {
-							console.warn("Roo Code <Language Model API>: Invalid tool input received:", chunk.input)
+							console.warn("Synthience Coder <Language Model API>: Invalid tool input received:", chunk.input)
 							continue
 						}
 
@@ -405,7 +405,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 						accumulatedText += toolCallText
 
 						// Log tool call for debugging
-						console.debug("Roo Code <Language Model API>: Processing tool call:", {
+						console.debug("Synthience Coder <Language Model API>: Processing tool call:", {
 							name: chunk.name,
 							callId: chunk.callId,
 							inputSize: JSON.stringify(chunk.input).length,
@@ -416,12 +416,12 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 							text: toolCallText,
 						}
 					} catch (error) {
-						console.error("Roo Code <Language Model API>: Failed to process tool call:", error)
+						console.error("Synthience Coder <Language Model API>: Failed to process tool call:", error)
 						// Continue processing other chunks even if one fails
 						continue
 					}
 				} else {
-					console.warn("Roo Code <Language Model API>: Unknown chunk type received:", chunk)
+					console.warn("Synthience Coder <Language Model API>: Unknown chunk type received:", chunk)
 				}
 			}
 
@@ -439,11 +439,11 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			this.ensureCleanState()
 
 			if (error instanceof vscode.CancellationError) {
-				throw new Error("Roo Code <Language Model API>: Request cancelled by user")
+				throw new Error("Synthience Coder <Language Model API>: Request cancelled by user")
 			}
 
 			if (error instanceof Error) {
-				console.error("Roo Code <Language Model API>: Stream error details:", {
+				console.error("Synthience Coder <Language Model API>: Stream error details:", {
 					message: error.message,
 					stack: error.stack,
 					name: error.name,
@@ -454,13 +454,13 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			} else if (typeof error === "object" && error !== null) {
 				// Handle error-like objects
 				const errorDetails = JSON.stringify(error, null, 2)
-				console.error("Roo Code <Language Model API>: Stream error object:", errorDetails)
-				throw new Error(`Roo Code <Language Model API>: Response stream error: ${errorDetails}`)
+				console.error("Synthience Coder <Language Model API>: Stream error object:", errorDetails)
+				throw new Error(`Synthience Coder <Language Model API>: Response stream error: ${errorDetails}`)
 			} else {
 				// Fallback for unknown error types
 				const errorMessage = String(error)
-				console.error("Roo Code <Language Model API>: Unknown stream error:", errorMessage)
-				throw new Error(`Roo Code <Language Model API>: Response stream error: ${errorMessage}`)
+				console.error("Synthience Coder <Language Model API>: Unknown stream error:", errorMessage)
+				throw new Error(`Synthience Coder <Language Model API>: Response stream error: ${errorMessage}`)
 			}
 		}
 	}
@@ -480,7 +480,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			// Log any missing properties for debugging
 			for (const [prop, value] of Object.entries(requiredProps)) {
 				if (!value && value !== 0) {
-					console.warn(`Roo Code <Language Model API>: Client missing ${prop} property`)
+					console.warn(`Synthience Coder <Language Model API>: Client missing ${prop} property`)
 				}
 			}
 
@@ -511,7 +511,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			? stringifyVsCodeLmModelSelector(this.options.vsCodeLmModelSelector)
 			: "vscode-lm"
 
-		console.debug("Roo Code <Language Model API>: No client available, using fallback model info")
+		console.debug("Synthience Coder <Language Model API>: No client available, using fallback model info")
 
 		return {
 			id: fallbackId,

--- a/src/core/CodeActionProvider.ts
+++ b/src/core/CodeActionProvider.ts
@@ -3,9 +3,9 @@ import * as path from "path"
 import { ClineProvider } from "./webview/ClineProvider"
 
 export const ACTION_NAMES = {
-	EXPLAIN: "Roo Code: Explain Code",
-	FIX: "Roo Code: Fix Code",
-	IMPROVE: "Roo Code: Improve Code",
+	EXPLAIN: "Synthience Coder: Explain Code",
+	FIX: "Synthience Coder: Fix Code",
+	IMPROVE: "Synthience Coder: Improve Code",
 } as const
 
 const COMMAND_IDS = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,44 +1,29 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import delay from "delay"
 import * as vscode from "vscode"
-import { ClineProvider } from "./core/webview/ClineProvider"
+import { SynthienceProvider } from "./core/webview/SynthienceProvider"
 import { createClineAPI } from "./exports"
-import "./utils/path" // necessary to have access to String.prototype.toPosix
+import "./utils/path"
 import { ACTION_NAMES, CodeActionProvider } from "./core/CodeActionProvider"
 import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
 
-/*
-Built using https://github.com/microsoft/vscode-webview-ui-toolkit
-
-Inspired by
-https://github.com/microsoft/vscode-webview-ui-toolkit-samples/tree/main/default/weather-webview
-https://github.com/microsoft/vscode-webview-ui-toolkit-samples/tree/main/frameworks/hello-world-react-cra
-
-*/
-
 let outputChannel: vscode.OutputChannel
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	outputChannel = vscode.window.createOutputChannel("Roo-Code")
+	outputChannel = vscode.window.createOutputChannel("Synthience-Coder")
 	context.subscriptions.push(outputChannel)
 
-	outputChannel.appendLine("Roo-Code extension activated")
+	outputChannel.appendLine("Synthience-Coder extension activated")
 
-	// Get default commands from configuration
 	const defaultCommands = vscode.workspace.getConfiguration("roo-cline").get<string[]>("allowedCommands") || []
 
-	// Initialize global state if not already set
 	if (!context.globalState.get("allowedCommands")) {
 		context.globalState.update("allowedCommands", defaultCommands)
 	}
 
-	const sidebarProvider = new ClineProvider(context, outputChannel)
+	const sidebarProvider = new SynthienceProvider(context, outputChannel)
 
 	context.subscriptions.push(
-		vscode.window.registerWebviewViewProvider(ClineProvider.sideBarId, sidebarProvider, {
+		vscode.window.registerWebviewViewProvider(SynthienceProvider.sideBarId, sidebarProvider, {
 			webviewOptions: { retainContextWhenHidden: true },
 		}),
 	)
@@ -65,36 +50,30 @@ export function activate(context: vscode.ExtensionContext) {
 	)
 
 	const openClineInNewTab = async () => {
-		outputChannel.appendLine("Opening Roo Code in new tab")
-		// (this example uses webviewProvider activation event which is necessary to deserialize cached webview, but since we use retainContextWhenHidden, we don't need to use that event)
-		// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
-		const tabProvider = new ClineProvider(context, outputChannel)
-		//const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined
+		outputChannel.appendLine("Opening Synthience Coder in new tab")
+		const tabProvider = new SynthienceProvider(context, outputChannel)
 		const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
 
-		// Check if there are any visible text editors, otherwise open a new group to the right
 		const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
 		if (!hasVisibleEditors) {
 			await vscode.commands.executeCommand("workbench.action.newGroupRight")
+			const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
+
+			const panel = vscode.window.createWebviewPanel(SynthienceProvider.tabPanelId, "Synthience Coder", targetCol, {
+				enableScripts: true,
+				retainContextWhenHidden: true,
+				localResourceRoots: [context.extensionUri],
+			})
+
+			panel.iconPath = {
+				light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "rocket.png"),
+				dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "rocket.png"),
+			}
+			tabProvider.resolveWebviewView(panel)
+
+			await delay(100)
+			await vscode.commands.executeCommand("workbench.action.lockEditorGroup")
 		}
-		const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
-
-		const panel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Roo Code", targetCol, {
-			enableScripts: true,
-			retainContextWhenHidden: true,
-			localResourceRoots: [context.extensionUri],
-		})
-		// TODO: use better svg icon with light and dark variants (see https://stackoverflow.com/questions/58365687/vscode-extension-iconpath)
-
-		panel.iconPath = {
-			light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "rocket.png"),
-			dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "rocket.png"),
-		}
-		tabProvider.resolveWebviewView(panel)
-
-		// Lock the editor group so clicking on files doesn't open them over the panel
-		await delay(100)
-		await vscode.commands.executeCommand("workbench.action.lockEditorGroup")
 	}
 
 	context.subscriptions.push(vscode.commands.registerCommand("roo-cline.popoutButtonClicked", openClineInNewTab))
@@ -102,7 +81,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("roo-cline.settingsButtonClicked", () => {
-			//vscode.window.showInformationMessage(message)
 			sidebarProvider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
 		}),
 	)
@@ -113,13 +91,6 @@ export function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 
-	/*
-	We use the text document content provider API to show the left side for diff view by creating a virtual document for the original content. This makes it readonly so users know to edit the right side if they want to keep their changes.
-
-	- This API allows you to create readonly documents in VSCode from arbitrary sources, and works by claiming an uri-scheme for which your provider then returns text contents. The scheme must be provided when registering a provider and cannot change afterwards.
-	- Note how the provider doesn't create uris for virtual documents - its role is to provide contents given such an uri. In return, content providers are wired into the open document logic so that providers are always considered.
-	https://code.visualstudio.com/api/extension-guides/virtual-documents
-	*/
 	const diffContentProvider = new (class implements vscode.TextDocumentContentProvider {
 		provideTextDocumentContent(uri: vscode.Uri): string {
 			return Buffer.from(uri.query, "base64").toString("utf-8")
@@ -129,11 +100,10 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.workspace.registerTextDocumentContentProvider(DIFF_VIEW_URI_SCHEME, diffContentProvider),
 	)
 
-	// URI Handler
 	const handleUri = async (uri: vscode.Uri) => {
 		const path = uri.path
 		const query = new URLSearchParams(uri.query.replace(/\+/g, "%2B"))
-		const visibleProvider = ClineProvider.getVisibleInstance()
+		const visibleProvider = SynthienceProvider.getVisibleInstance()
 		if (!visibleProvider) {
 			return
 		}
@@ -159,14 +129,12 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 	context.subscriptions.push(vscode.window.registerUriHandler({ handleUri }))
 
-	// Register code actions provider
 	context.subscriptions.push(
 		vscode.languages.registerCodeActionsProvider({ pattern: "**/*" }, new CodeActionProvider(), {
 			providedCodeActionKinds: CodeActionProvider.providedCodeActionKinds,
 		}),
 	)
 
-	// Helper function to handle code actions
 	const registerCodeAction = (
 		context: vscode.ExtensionContext,
 		command: string,
@@ -195,13 +163,12 @@ export function activate(context: vscode.ExtensionContext) {
 						...(userInput ? { userInput } : {}),
 					}
 
-					await ClineProvider.handleCodeAction(command, promptType, params)
+					await SynthienceProvider.handleCodeAction(command, promptType, params)
 				},
 			),
 		)
 	}
 
-	// Helper function to register both versions of a code action
 	const registerCodeActionPair = (
 		context: vscode.ExtensionContext,
 		baseCommand: string,
@@ -209,19 +176,15 @@ export function activate(context: vscode.ExtensionContext) {
 		inputPrompt?: string,
 		inputPlaceholder?: string,
 	) => {
-		// Register new task version
 		registerCodeAction(context, baseCommand, promptType, true, inputPrompt, inputPlaceholder)
-
-		// Register current task version
 		registerCodeAction(context, `${baseCommand}InCurrentTask`, promptType, false, inputPrompt, inputPlaceholder)
 	}
 
-	// Register code action commands
 	registerCodeActionPair(
 		context,
 		"roo-cline.explainCode",
 		"EXPLAIN",
-		"What would you like Roo to explain?",
+		"What would you like Synthience to explain?",
 		"E.g. How does the error handling work?",
 	)
 
@@ -229,7 +192,7 @@ export function activate(context: vscode.ExtensionContext) {
 		context,
 		"roo-cline.fixCode",
 		"FIX",
-		"What would you like Roo to fix?",
+		"What would you like Synthience to fix?",
 		"E.g. Maintain backward compatibility",
 	)
 
@@ -237,14 +200,13 @@ export function activate(context: vscode.ExtensionContext) {
 		context,
 		"roo-cline.improveCode",
 		"IMPROVE",
-		"What would you like Roo to improve?",
+		"What would you like Synthience to improve?",
 		"E.g. Focus on performance optimization",
 	)
 
 	return createClineAPI(outputChannel, sidebarProvider)
 }
 
-// This method is called when your extension is deactivated
 export function deactivate() {
-	outputChannel.appendLine("Roo-Code extension deactivated")
+	outputChannel.appendLine("Synthience-Coder extension deactivated")
 }

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -16,7 +16,7 @@ export class TerminalRegistry {
 	static createTerminal(cwd?: string | vscode.Uri | undefined): TerminalInfo {
 		const terminal = vscode.window.createTerminal({
 			cwd,
-			name: "Roo Code",
+			name: "Synthience Coder",
 			iconPath: new vscode.ThemeIcon("rocket"),
 			env: {
 				PAGER: "cat",

--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -28,17 +28,17 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 				style={{ position: "absolute", top: "8px", right: "8px" }}>
 				<span className="codicon codicon-close"></span>
 			</VSCodeButton>
-			<h2 style={{ margin: "0 0 8px" }}>🎉{"  "}Introducing Roo Code 3.2</h2>
+			<h2 style={{ margin: "0 0 8px" }}>🎉{"  "}Introducing Synthience Coder 3.2</h2>
 
 			<p style={{ margin: "5px 0px" }}>
-				Our biggest update yet is here - we're officially changing our name from Roo Cline to Roo Code! After
+				Our biggest update yet is here - we're officially changing our name from Roo Cline to Synthience Coder! After
 				growing beyond 50,000 installations, we're ready to chart our own course. Our heartfelt thanks to
 				everyone in the Cline community who helped us reach this milestone.
 			</p>
 
 			<h3 style={{ margin: "12px 0 8px" }}>Custom Modes: Celebrating Our New Identity</h3>
 			<p style={{ margin: "5px 0px" }}>
-				To mark this new chapter, we're introducing the power to shape Roo Code into any role you need! Create
+				To mark this new chapter, we're introducing the power to shape Synthience Coder into any role you need! Create
 				specialized personas and create an entire team of agents with deeply customized prompts:
 				<ul style={{ margin: "4px 0 6px 20px", padding: 0 }}>
 					<li>QA Engineers who write thorough test cases and catch edge cases</li>
@@ -52,7 +52,7 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 
 			<h3 style={{ margin: "12px 0 8px" }}>Join Us for the Next Chapter</h3>
 			<p style={{ margin: "5px 0px" }}>
-				We can't wait to see how you'll push Roo Code's potential even further! Share your custom modes and join
+				We can't wait to see how you'll push Synthience Coder's potential even further! Share your custom modes and join
 				the discussion at{" "}
 				<VSCodeLink href="https://www.reddit.com/r/RooCode" style={{ display: "inline" }}>
 					reddit.com/r/RooCode

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -231,7 +231,7 @@ const OpenRouterModelPicker: React.FC = () => {
 					<VSCodeLink style={{ display: "inline", fontSize: "inherit" }} href="https://openrouter.ai/models">
 						OpenRouter.
 					</VSCodeLink>
-					If you're unsure which model to choose, Roo Code works best with{" "}
+					If you're unsure which model to choose, Synthience Coder works best with{" "}
 					<VSCodeLink
 						style={{ display: "inline", fontSize: "inherit" }}
 						onClick={() => handleModelChange("anthropic/claude-3.5-sonnet:beta")}>


### PR DESCRIPTION
Rebrand the extension from "Roo Code" to "Synthience Coder".

* **package.json**: Change the `name` to "synthience-coder", `displayName` to "Synthience Coder", `publisher` to "SynthienceInc", and update the `repository` and `homepage` URLs.
* **README.md**: Update all references from "Roo Code" and "Roo Cline" to "Synthience Coder". Update download, review, and repository links.
* **CHANGELOG.md**: Update all references from "Roo Code" and "Roo Cline" to "Synthience Coder".
* **.github/ISSUE_TEMPLATE/config.yml**: Update feature request and review URLs to point to the new repository and marketplace links.

